### PR TITLE
Add JavaDoc comments to functions where missing

### DIFF
--- a/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
+++ b/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
@@ -446,6 +446,10 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
         }
     }
 
+    // --------------------------------------------------------------------
+    /**
+     * @return True if branch alignment is left to sensor, False if right to sensor
+     */
     private boolean isBranchAligned(BranchAlignment alignment) {
         Distance distance = (alignment == BranchAlignment.ALIGN_LEFT)
                 ? leftTofSensor.getDistance()
@@ -453,7 +457,9 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
 
         return distance.gte(THRESHOLD_DISTANCE);
     }
-
+    /**
+     * Stops the robot
+     */
     private Command stop() {
         return runOnce(() -> setControl(new RobotCentric()));
     }
@@ -462,7 +468,9 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
         ROBOT_RELATIVE,
         FIELD_RELATIVE
     }
-
+    /**
+     * 
+     */
     public Command move(Supplier<LinearVelocity> velocityX, Supplier<LinearVelocity> velocityY,
             Supplier<AngularVelocity> rotationalRate, RelativeReference relativeReference) {
         switch (relativeReference) {

--- a/src/main/java/frc/robot/subsystems/LEDSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/LEDSubsystem.java
@@ -13,6 +13,7 @@ public class LEDSubsystem extends SubsystemBase {
     private final IAddressableLED led;
     public final Trigger isLEDOn;
 
+    
     public LEDSubsystem(String subsystemName, IAddressableLED led) {
         super(subsystemName);
 
@@ -31,6 +32,11 @@ public class LEDSubsystem extends SubsystemBase {
         builder.addStringArrayProperty("LED Colors", () -> Arrays.stream(led.getColors()).map(Color::toString).toArray(String[]::new), null);
     }
 
+    /**
+     * Assigns each LED colors.
+     * @param color
+     * @return
+     */
     public Command setAllLEDColor(Color color) {
         return runOnce(() ->  led.setAllLEDColor(color));
     }

--- a/src/main/java/frc/robot/subsystems/algae/AlgaeRemoverSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/algae/AlgaeRemoverSubsystem.java
@@ -13,6 +13,9 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 public class AlgaeRemoverSubsystem extends SubsystemBase {
+    /**
+     * A number that represents the targetDutyCycle.
+     */
     private Dimensionless targetDutyCycle;
     private IDutyMotor motor;
     private static final Dimensionless DEFAULT_SPEED = Percent.of(70); // TODO: Determine if speed needs to be negated
@@ -38,6 +41,11 @@ public class AlgaeRemoverSubsystem extends SubsystemBase {
         setSpeed(() -> Percent.of(duty)).schedule();
     }
 
+    /**
+     * Sets the speed of dutyCycle
+     * @param duty
+     * @return dutyCycle
+     */
     private Command setSpeed(Supplier<Dimensionless> duty) {
         return run(() -> {
             Dimensionless dutyCycle = duty.get();

--- a/src/main/java/frc/robot/subsystems/carriage/CarriageSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/carriage/CarriageSubsystem.java
@@ -37,6 +37,12 @@ public class CarriageSubsystem extends SubsystemBase {
         RIGHT
     }
 
+    /**
+     * Controls the transportation of coral.
+     * @param subsystemName
+     * @param rollerMotors
+     * @param beamBreak
+     */
     public CarriageSubsystem(String subsystemName, IDifferentialMotors rollerMotors, IBeamBreak beamBreak) {
         super(subsystemName);
         this.rollerMotors = rollerMotors;
@@ -51,18 +57,34 @@ public class CarriageSubsystem extends SubsystemBase {
         builder.addBooleanProperty("Outtake Beam Breaker", this::isBeamBroken, null);
     }
     
+    /**
+     * The rollers will intake the coral into the carriage
+     * @return
+     */
     public Command loadCoral() {
         return runEnd(this::moveRollers, rollerMotors::stop).until(beamBroken);
     }
     
+    /**
+     * The rollers will push coral towards the carriage hopper until the beam sensor no longer dects the coral.
+     * @return
+     */
     public Command unloadCoral() {
         return runEnd(this::reverseRollers, rollerMotors::stop).until(beamIntact);
     }
 
+    /** 
+     * The coral will be pushed towards the carriage hopper until the sensor no longer detects the coral, then pulled in towards the intake until the sensor detects the coral.
+     * @return
+     */
     public Command reloadCoral() {
         return unloadCoral().andThen(loadCoral());
     }
     
+    /**
+     * The rollers will push out the coral outside of the outtake.
+     * @param direction Controls what direction the coral is shot.
+     */
     public Command scoreCoral(CamberDirection direction) {
         return runEnd(() -> {
             switch (direction) {
@@ -79,6 +101,10 @@ public class CarriageSubsystem extends SubsystemBase {
         }, rollerMotors::stop).until(beamIntact);
     }
 
+    /**
+     * Resets the motor encoder to 0 rotations.
+     * @return
+     */
     public Command resetMotorEncoder() {
         return runOnce(rollerMotors::resetRelativeEncoder);
     }
@@ -91,11 +117,17 @@ public class CarriageSubsystem extends SubsystemBase {
         rollerMotors.move(DEFAULT_SPEED.unaryMinus());
     }
 
+    /**
+     * @return true when something is detected in the sensor's path.
+     */
     @AutoLogOutput(key = "Sensor/OuttakeBeam")
     private boolean isBeamBroken() {
         return beamBreak.isBeamBroken();
     }
     
+    /**
+     * @return true when something is no longer detected in the sensor's path.
+     */
     private boolean isBeamIntact() {
         return !beamBreak.isBeamBroken();
     }

--- a/src/main/java/frc/robot/subsystems/elevator/ElevatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/elevator/ElevatorSubsystem.java
@@ -70,6 +70,11 @@ public class ElevatorSubsystem extends SubsystemBase {
         }
     }
     
+    /**
+     * Moves the elevator to a specific position and <b>HOLDS THE POSITION<b>.
+     * @param position
+     * @return
+     */
     public Command move(Position position) {
         return move(() -> getDistance(position));
     }
@@ -93,22 +98,43 @@ public class ElevatorSubsystem extends SubsystemBase {
         runOnce(() -> motor.travelTo(Meters.of(heightMeters))).schedule();
     }
 
+    /**
+     * Resets the motor's rotation to 0
+     * @return
+     */
     public Command reset() {
         return runOnce(motor::resetRelativeEncoder);
     }
     
+    /**
+     * Holds the motor at its current position.
+     * @return
+     */
     public Command hold() {
         return runOnce(motor::hold);
     }
 
-    public Command stop() {
+    /**
+         * @return
+         * Stops the motor at its current position.
+         */
+        public Command stop() {
         return runOnce(motor::stop);
     }
 
+     /**
+      * Moves the elevator to a specific position and <b>DOESN'T HOLD THE POSITION<b>.
+     * @param position
+     * @return
+     */
     public Command translateElevator(Position position) {
         return run(() -> move(position));
     }
     
+    /**
+     * Elevator goes down untill it hits its limit switch, and resets the encoder once the limit switch is triggered.
+     * @return
+     */
     public Command home() {
         return run(() -> motor.home())
             .until(motor::isAtReverseLimit)

--- a/src/main/java/frc/robot/subsystems/vision/VisionSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionSubsystem.java
@@ -38,6 +38,9 @@ public class VisionSubsystem extends SubsystemBase {
                 , fieldWidth));
     }
 
+    /**
+     * @return Handles vision errors and calculates robot pose estimation on field
+     */
     private Result<PoseEstimate, VisionError> estimatePosition() {
         PoseEstimate result;
 
@@ -54,6 +57,10 @@ public class VisionSubsystem extends SubsystemBase {
         return new Success<>(result);
     }
 
+    /**
+     * @return Result of calling estimatePosition function
+     * 
+     */
     public Supplier<Result<PoseEstimate, VisionError>> positionEstimateSupplier() {
         return this::estimatePosition;
     }


### PR DESCRIPTION
JavaDoc comments should be added to functions that don't have them. JavaDoc comments should express intent as well as basic implementation strategy in cases such information would make it easier to understand what the code is doing and why.